### PR TITLE
MBS-10217: Remove markingscheme from user preferences

### DIFF
--- a/questiontype.php
+++ b/questiontype.php
@@ -93,7 +93,7 @@ class qtype_aitext extends question_type {
     }
 
     /**
-     * Markscheme may not be required here
+     * Store default to user preferences.
      *
      * @param stdClass $fromform
      * @return void
@@ -102,8 +102,6 @@ class qtype_aitext extends question_type {
         parent::save_defaults_for_new_questions($fromform);
         $this->set_default_value('responseformat', $fromform->responseformat);
         $this->set_default_value('responsefieldlines', $fromform->responsefieldlines);
-        $this->set_default_value('markscheme', $fromform->markscheme);
-
     }
     /**
      * Write the question data from the editing form to the database


### PR DESCRIPTION
An error is thrown if the markingscheme prompt is very long:
<img width="3193" height="1173" alt="image" src="https://github.com/user-attachments/assets/7861c8c6-d11c-4aad-9bac-d1f863c36cea" />

The reason for this is that the markingscheme prompt is saved as a user preference and the database field is not long enough here.

Contribution suggestion: Remove the saving in the user preferences because it is not necessary.